### PR TITLE
Update tokenlist.json

### DIFF
--- a/bsc/tokenlist.json
+++ b/bsc/tokenlist.json
@@ -10,6 +10,14 @@
         "decimals": "",
         "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/7192.png"
       },
+         {
+        "name": "Safu Inu",
+        "symbol": "SFI",
+        "address": "0x2Af9bDCFBe74a64a3A2B258700259Bc42eA6F2f4",
+        "chainId": 56,
+        "decimals": "18",
+        "logoURI": "https://safuinu.space/theme-assets/images/frontlogo.png"
+      },
       {
         "name": "Bogged Finance",
         "symbol": "BOG",


### PR DESCRIPTION
Safu Inu Tax is 11% of each transaction
- Ownership renounced
- Liquidity locked for 200 years
- Buyback: 2%
- Marketing: 5%
- 1.5x sell fee
- Team/Development: 2%
- BNB auto-reflections: 2%
- Total supply 100 million $SFI
- Max wallet 0.5% of total supply
safuinu.space